### PR TITLE
Fixing missing paste names (+target platform set to newer JS)

### DIFF
--- a/src/PasteClient.ts
+++ b/src/PasteClient.ts
@@ -32,6 +32,7 @@ class PasteClient {
       body: this.encode({
         api_dev_key: this.apiKey,
         api_option: "paste",
+        api_paste_name: options.name ?? "Untitled",
         api_paste_code: options.code,
         api_paste_format: options.format ?? "javascript",
         api_paste_private: options.publicity ?? 0,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "target": "es2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
Hi Casper,
I saw your package on npm and I want to replace the now highly outdated and bloated pastebin-ts to it. When I tried it in my discord bot, I spotted a mistake (the paste name wasn't set) so I thought why not try and fix it. :)
Keep up the good work!
Márton Polgár