### PR TITLE
feat: support use custom domain

### DIFF
--- a/src/PasteClient.ts
+++ b/src/PasteClient.ts
@@ -4,8 +4,9 @@ import { CreateOptions, GetPastesOptions, ParsedPaste, DeletePasteOptions } from
 
 export default class PasteClient {
   private apiKey: string;
-  private pasteBinUrl = "https://pastebin.com/api/api_post.php";
-  private loginUrl = "https://pastebin.com/api/api_login.php";
+  private domain = "pastebin.com";
+  private pasteBinUrl = `https://${this.domain}/api/api_post.php`;
+  private loginUrl = `https://${this.domain}/api/api_login.php`;
 
   constructor(apiKey: string) {
     if (typeof apiKey !== "string" || !apiKey) {
@@ -13,6 +14,14 @@ export default class PasteClient {
     }
 
     this.apiKey = apiKey;
+  }
+
+  /**
+   * set the API domain
+   * @param {string} domain The domain of your reverse proxy server.
+   */
+  async setDomain(domain = "pastebin.com"): Promise<void> {
+    this.domain = domain;
   }
 
   /**

--- a/src/PasteClient.ts
+++ b/src/PasteClient.ts
@@ -20,7 +20,7 @@ export default class PasteClient {
    * set the API domain
    * @param {string} domain The domain of your reverse proxy server.
    */
-  async setDomain(domain = "pastebin.com"): Promise<void> {
+  setDomain(domain = "pastebin.com"): void {
     this.domain = domain;
   }
 


### PR DESCRIPTION
Hello, thanks for the awesome library.
We are using this library in a frontend application, but pastebin.com didn't provide CORS header in their API's response. We will setup a reverse proxy to resolve this problem. So we need to change the domain of the API.
So I add this util funtion, hope it can be merged soon. :)
